### PR TITLE
[PR](Oauth for mobile) : Add configuration adapted for mobile

### DIFF
--- a/__tests__/config/axios.simple.test.ts
+++ b/__tests__/config/axios.simple.test.ts
@@ -28,17 +28,15 @@ delete (window as any).location;
 window.location = mockLocation as any;
 
 describe('axios configuration', () => {
-  let axios: typeof import('axios').default;
+  let axios: typeof import('../../src/config/axios').default;
 
   beforeEach(async () => {
     localStorageMock.clear();
     jest.clearAllMocks();
     mockLocation.pathname = '/test';
     jest.resetModules();
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    axios = require('axios').default;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('../../src/config/axios');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  axios = require('../../src/config/axios').default;
   });
 
   afterAll(() => {

--- a/__tests__/config/axios.simple.test.ts
+++ b/__tests__/config/axios.simple.test.ts
@@ -35,8 +35,7 @@ describe('axios configuration', () => {
     jest.clearAllMocks();
     mockLocation.pathname = '/test';
     jest.resetModules();
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  axios = require('../../src/config/axios').default;
+    axios = require('../../src/config/axios').default;
   });
 
   afterAll(() => {

--- a/src/app/oauth-callback/page.tsx
+++ b/src/app/oauth-callback/page.tsx
@@ -21,6 +21,8 @@ function isProbablyMobileApp(): boolean {
   }
 }
 
+const DEEPLINK_WAIT_MS = 800;
+
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function parseState(raw: string | null): { app_redirect_uri?: string; returnUrl?: string; provider?: string } | null {
@@ -47,10 +49,10 @@ function parseState(raw: string | null): { app_redirect_uri?: string; returnUrl?
 function getProviderFromState(state: { provider?: string } | null): string {
   try {
     const stored = localStorage.getItem('oauth_provider');
-    return (stored || state?.provider || 'github').toLowerCase();
+    return (stored || state?.provider || '').toLowerCase();
   } catch (e) {
     console.warn('getProviderFromState failed to read localStorage:', e);
-    return (state?.provider || 'github').toLowerCase();
+    return (state?.provider || '').toLowerCase();
   }
 }
 
@@ -243,7 +245,7 @@ export default function OAuthCallbackPage() {
             console.warn('Deep link navigation failed:', e, 'dl:', dl);
           }
 
-          await delay(800);
+          await delay(DEEPLINK_WAIT_MS);
           setShowBrowserFallback(true);
           setMessage('If nothing happens, you can continue in the browser below.');
           return;

--- a/src/app/oauth-callback/page.tsx
+++ b/src/app/oauth-callback/page.tsx
@@ -24,6 +24,7 @@ function isProbablyMobileApp(): boolean {
 const DEEPLINK_WAIT_MS = 800;
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const DEFAULT_APP_REDIRECT = 'areamobile://oauthredirect';
 
 function parseState(raw: string | null): { app_redirect_uri?: string; returnUrl?: string; provider?: string } | null {
   if (!raw) return null;
@@ -106,19 +107,10 @@ export default function OAuthCallbackPage() {
         window.location.replace(safe);
         return;
       }
-      try {
-        const stored = localStorage.getItem('oauth_return_url');
-        if (stored && stored === returnUrl) {
-          window.location.replace(returnUrl);
-          return;
-        }
-      } catch (e) {
-        console.warn('Error reading oauth_return_url from localStorage:', e);
-      }
 
       console.warn('Blocked unsafe returnUrl redirect:', returnUrl);
       window.location.replace('/');
-    }, 800);
+    }, DEEPLINK_WAIT_MS);
   }, [refreshAuth]);
 
   function validateReturnUrl(url: string | undefined | null): string | null {
@@ -237,7 +229,7 @@ export default function OAuthCallbackPage() {
           setStatus('processing');
           setMessage('Returning to the app...');
 
-          const appRedirect = state?.app_redirect_uri || 'areamobile://oauthredirect';
+          const appRedirect = state?.app_redirect_uri || DEFAULT_APP_REDIRECT;
           const dl = `${appRedirect}?code=${encodeURIComponent(code)}&provider=${encodeURIComponent(provider)}`;
           try {
             window.location.href = dl;

--- a/src/app/oauth-callback/page.tsx
+++ b/src/app/oauth-callback/page.tsx
@@ -55,12 +55,9 @@ export default function OAuthCallbackPage() {
 
   async function fetchCurrentUser() {
     try {
-      console.debug('[oauth] GET /api/auth/me (check)');
       const me = await axios.get('/api/auth/me');
-      console.debug('[oauth] /api/auth/me ->', me?.status);
       if (me?.status === 200) return me?.data;
     } catch (e) {
-      console.debug('[oauth] /api/auth/me -> error', e);
     }
     return null;
   }
@@ -85,14 +82,11 @@ export default function OAuthCallbackPage() {
     try {
       setStatus('processing');
       setMessage('Completing authentication in browser...');
-      console.debug('[oauth] POST', url);
       const response = await axios.post(url, { code });
-      console.debug('[oauth] POST', url, '->', response?.status);
 
       if (response.status === 200) {
         await handleSuccess(isLinkMode ? 'Account linked successfully! Redirecting...' : 'Authentication successful! Redirecting...', returnUrl);
       } else {
-        // Unexpected status: check /me as fallback
         const me = await fetchCurrentUser();
         if (me) {
           await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
@@ -103,10 +97,8 @@ export default function OAuthCallbackPage() {
       }
     } catch (err: unknown) {
       console.error('OAuth exchange error (forced web):', err);
-      // Try fallback to /me
       const me = await fetchCurrentUser();
       if (me) {
-        console.debug('[oauth] fallback /me after failed exchange -> success');
         await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
         return;
       }
@@ -203,9 +195,7 @@ export default function OAuthCallbackPage() {
       try {
         setStatus('processing');
         setMessage('Exchanging authorization code...');
-        console.debug('[oauth] POST', url);
         const response = await axios.post(url, { code });
-        console.debug('[oauth] POST', url, '->', response?.status);
 
         if (response.status === 200) {
           await handleSuccess(isLinkMode ? 'Account linked successfully! Redirecting...' : 'Authentication successful! Redirecting...', returnUrl);
@@ -222,7 +212,6 @@ export default function OAuthCallbackPage() {
         console.error('OAuth exchange error:', err);
         const me = await fetchCurrentUser();
         if (me) {
-          console.debug('[oauth] fallback /me after failed exchange -> success');
           await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
           return;
         }

--- a/src/app/oauth-callback/page.tsx
+++ b/src/app/oauth-callback/page.tsx
@@ -1,135 +1,270 @@
 "use client";
-import { useEffect, useState, Suspense } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Container, Title, Text, Loader, Alert } from '@mantine/core';
+import { Container, Title, Text, Loader, Alert, Button, Stack } from '@mantine/core';
 import { useAuth } from '../../hooks/useAuth';
 import axios from '../../config/axios';
+import { isAxiosError } from 'axios';
 
-function OAuthCallbackContent() {
+type Provider = 'github' | 'google';
+
+function isProbablyMobileApp(): boolean {
+  try {
+    if (typeof window === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    const expectFlag = localStorage.getItem('oauth_expect_mobile') === 'true';
+    const win = window as Window & { ReactNativeWebView?: unknown };
+    const hasReactNativeWebView = typeof win.ReactNativeWebView !== 'undefined';
+    return expectFlag || ua.includes('Expo') || hasReactNativeWebView || /Android|iPhone|iPad|iPod/i.test(ua);
+  } catch {
+    return false;
+  }
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function parseState(raw: string | null): { app_redirect_uri?: string; returnUrl?: string; provider?: Provider } | null {
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+}
+
+function getMessageFromUnknown(data: unknown): string | undefined {
+  if (!data) return undefined;
+  if (typeof data === 'object' && data !== null) {
+    const d = data as Record<string, unknown>;
+    const m = d['message'];
+    if (typeof m === 'string') return m;
+  }
+  return undefined;
+}
+
+export default function OAuthCallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { refreshAuth } = useAuth();
   const [status, setStatus] = useState<'processing' | 'success' | 'error'>('processing');
-  const [message, setMessage] = useState<string>('');
-  const [hasProcessed, setHasProcessed] = useState(false);
+  const [message, setMessage] = useState<string>('Preparing authentication...');
+  const [showBrowserFallback, setShowBrowserFallback] = useState(false);
+
+  const processedRef = useRef(false);
+
+  async function fetchCurrentUser() {
+    try {
+      console.debug('[oauth] GET /api/auth/me (check)');
+      const me = await axios.get('/api/auth/me');
+      console.debug('[oauth] /api/auth/me ->', me?.status);
+      if (me?.status === 200) return me?.data;
+    } catch (e) {
+      console.debug('[oauth] /api/auth/me -> error', e);
+    }
+    return null;
+  }
+
+  const handleSuccess = useCallback(async (messageText: string, returnUrl: string) => {
+    setStatus('success');
+    setMessage(messageText);
+    localStorage.removeItem('oauth_link_mode');
+    localStorage.removeItem('oauth_provider');
+    localStorage.removeItem('oauth_return_url');
+    localStorage.removeItem('oauth_expect_mobile');
+
+    try { await refreshAuth?.(); } catch { /* no-op */ }
+
+    setTimeout(() => {
+      window.location.replace(returnUrl);
+    }, 800);
+  }, [refreshAuth]);
+
+  async function forceWebExchange(code: string, provider: Provider, isLinkMode: boolean, returnUrl: string) {
+    const url = isLinkMode ? `/api/oauth-link/${provider}/exchange` : `/api/oauth/${provider}/exchange`;
+    try {
+      setStatus('processing');
+      setMessage('Completing authentication in browser...');
+      console.debug('[oauth] POST', url);
+      const response = await axios.post(url, { code });
+      console.debug('[oauth] POST', url, '->', response?.status);
+
+      if (response.status === 200) {
+        await handleSuccess(isLinkMode ? 'Account linked successfully! Redirecting...' : 'Authentication successful! Redirecting...', returnUrl);
+      } else {
+        // Unexpected status: check /me as fallback
+        const me = await fetchCurrentUser();
+        if (me) {
+          await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
+        } else {
+          setStatus('error');
+          setMessage('Unexpected response during authentication');
+        }
+      }
+    } catch (err: unknown) {
+      console.error('OAuth exchange error (forced web):', err);
+      // Try fallback to /me
+      const me = await fetchCurrentUser();
+      if (me) {
+        console.debug('[oauth] fallback /me after failed exchange -> success');
+        await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
+        return;
+      }
+
+      setStatus('error');
+      let errorMessage = 'Server error during authentication';
+      if (isAxiosError(err)) {
+        const resp = err.response;
+        if (resp) {
+          const status = resp.status;
+          const data = resp.data as unknown;
+          if (status === 409) {
+            const d = data as { message?: string; suggestion?: string } | undefined;
+            errorMessage = d?.message || 'This account is already linked to another user';
+            if (d?.suggestion) errorMessage += '. ' + d.suggestion;
+          } else if (status === 400) {
+            const d = data as { message?: string; suggestion?: string } | undefined;
+            errorMessage = d?.message || 'Invalid request';
+            if (d?.suggestion) errorMessage += '. ' + d.suggestion;
+          } else if (status === 401) {
+            errorMessage = 'Invalid or expired authorization code';
+          } else {
+            const msg = getMessageFromUnknown(data);
+            if (typeof msg === 'string') errorMessage = msg;
+          }
+        }
+      }
+      setMessage(errorMessage);
+    }
+  }
 
   useEffect(() => {
-    const processCallback = async () => {
-      if (hasProcessed) return;
-      setHasProcessed(true);
+    if (processedRef.current) return;
+    processedRef.current = true;
 
+    (async () => {
       const code = searchParams.get('code');
       const error = searchParams.get('error');
       const errorDescription = searchParams.get('error_description');
+      const rawState = searchParams.get('state');
+      const state = parseState(rawState);
 
       if (error) {
         setStatus('error');
         setMessage(errorDescription || error || 'OAuth authentication failed');
-
-        setTimeout(() => {
-          router.push('/login?error=' + encodeURIComponent(error));
-        }, 3000);
+        setTimeout(() => router.push('/login?error=' + encodeURIComponent(error)), 2500);
         return;
       }
 
       if (!code) {
         setStatus('error');
         setMessage('No authorization code received');
-
-        setTimeout(() => {
-          router.push('/login');
-        }, 2000);
+        setTimeout(() => router.push('/login'), 1500);
         return;
       }
 
-      try {
-        setMessage('Exchanging authorization code...');
+      const isLinkMode = localStorage.getItem('oauth_link_mode') === 'true';
+      const storedProvider = (localStorage.getItem('oauth_provider') || state?.provider || 'github').toLowerCase();
+      const provider: Provider = storedProvider === 'google' ? 'google' : 'github';
+      const returnUrl = (state?.returnUrl && typeof state.returnUrl === 'string' ? state.returnUrl : (localStorage.getItem('oauth_return_url') || '/')) as string;
+      const forceWeb = searchParams.get('forceWeb') === '1';
 
-        const isLinkMode = localStorage.getItem('oauth_link_mode') === 'true';
-        const provider = localStorage.getItem('oauth_provider') || 'github';
+      const deeplinkKey = `oauth_deeplink_attempted_${code}`;
+      const alreadyTriedDeepLink = sessionStorage.getItem(deeplinkKey) === 'true';
 
-        let response;
-        if (isLinkMode) {
-          response = await axios.post(`/api/oauth-link/${provider}/exchange`, {
-            code: code
-          });
+      if (!forceWeb && isProbablyMobileApp()) {
+        if (!alreadyTriedDeepLink) {
+          try { sessionStorage.setItem(deeplinkKey, 'true'); } catch { }
+          setStatus('processing');
+          setMessage('Returning to the app...');
+
+          const appRedirect = state?.app_redirect_uri || 'areamobile://oauthredirect';
+          const dl = `${appRedirect}?code=${encodeURIComponent(code)}&provider=${encodeURIComponent(provider)}`;
+          try { window.location.href = dl; } catch { /* ignore */ }
+
+          await delay(800);
+          setShowBrowserFallback(true);
+          setMessage('If nothing happens, you can continue in the browser below.');
+          return;
         } else {
-          response = await axios.post(`/api/oauth/${provider}/exchange`, {
-            code: code
-          });
+          setShowBrowserFallback(true);
+          setMessage('If nothing happens, you can continue in the browser below.');
+          return;
         }
+      }
 
-        console.log('OAuth exchange response:', response);
+      const meBefore = await fetchCurrentUser();
+      if (meBefore) {
+        await handleSuccess('Authentication already completed. Redirecting...', returnUrl);
+        return;
+      }
+
+      const url = isLinkMode ? `/api/oauth-link/${provider}/exchange` : `/api/oauth/${provider}/exchange`;
+      try {
+        setStatus('processing');
+        setMessage('Exchanging authorization code...');
+        console.debug('[oauth] POST', url);
+        const response = await axios.post(url, { code });
+        console.debug('[oauth] POST', url, '->', response?.status);
 
         if (response.status === 200) {
-          setStatus('success');
-          localStorage.removeItem('oauth_link_mode');
-          localStorage.removeItem('oauth_provider');
-          const returnUrl = localStorage.getItem('oauth_return_url') || '/';
-          localStorage.removeItem('oauth_return_url');
-
-          if (isLinkMode) {
-            setMessage('Account linked successfully! Redirecting...');
-            setTimeout(() => {
-              window.location.href = returnUrl;
-            }, 1500);
+          await handleSuccess(isLinkMode ? 'Account linked successfully! Redirecting...' : 'Authentication successful! Redirecting...', returnUrl);
+        } else {
+          const me = await fetchCurrentUser();
+          if (me) {
+            await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
           } else {
-            setMessage('Authentication successful! Redirecting...');
-            setTimeout(() => {
-              window.location.href = returnUrl;
-            }, 1500);
+            setStatus('error');
+            setMessage('Unexpected response during authentication');
           }
-          setTimeout(() => {
-            window.location.reload();
-            router.push(returnUrl);
-          }, 2000);
         }
-    } catch (error: unknown) {
-        console.error('OAuth exchange error:', error);
+      } catch (err: unknown) {
+        console.error('OAuth exchange error:', err);
+        const me = await fetchCurrentUser();
+        if (me) {
+          console.debug('[oauth] fallback /me after failed exchange -> success');
+          await handleSuccess('Authentication completed (verified). Redirecting...', returnUrl);
+          return;
+        }
+
         setStatus('error');
-
-        let errorMessage = 'Authentication failed';
-        if (error && typeof error === 'object' && 'response' in error) {
-          const axiosError = error as { response: { status: number; data?: { message?: string; error?: string; suggestion?: string } } };
-          console.error('OAuth error details:', axiosError.response);
-          if (axiosError.response?.status === 409) {
-            const data = axiosError.response.data;
-            errorMessage = data?.message || 'This account is already linked to another user';
-            if (data?.suggestion) {
-              errorMessage += '. ' + data.suggestion;
+        let errorMessage = 'Server error during authentication';
+        if (isAxiosError(err)) {
+          const resp = err.response;
+          if (resp) {
+            const status = resp.status;
+            const data = resp.data as unknown;
+            if (status === 409) {
+              const d = data as { message?: string; suggestion?: string } | undefined;
+              errorMessage = d?.message || 'This account is already linked to another user';
+              if (d?.suggestion) errorMessage += '. ' + d.suggestion;
+            } else if (status === 400) {
+              const d = data as { message?: string; suggestion?: string } | undefined;
+              errorMessage = d?.message || 'Invalid request';
+              if (d?.suggestion) errorMessage += '. ' + d.suggestion;
+            } else if (status === 401) {
+              errorMessage = 'Invalid or expired authorization code';
+            } else {
+              const msg = getMessageFromUnknown(data);
+              if (typeof msg === 'string') errorMessage = msg;
             }
-          } else if (axiosError.response?.status === 400) {
-            const data = axiosError.response.data;
-            errorMessage = data?.message || 'Invalid request';
-            if (data?.suggestion) {
-              errorMessage += '. ' + data.suggestion;
-            }
-          } else if (axiosError.response?.status === 401) {
-            errorMessage = 'Invalid or expired authorization code';
-          } else if (axiosError.response?.status === 500) {
-            errorMessage = 'Server error during authentication';
-          } else if (axiosError.response?.data?.message) {
-            errorMessage = axiosError.response.data.message;
           }
         }
-
         setMessage(errorMessage);
 
-        const isLinkMode = localStorage.getItem('oauth_link_mode') === 'true';
-        localStorage.removeItem('oauth_link_mode');
-        localStorage.removeItem('oauth_provider');
         if (isLinkMode) {
           setTimeout(() => {
-            const returnUrl = localStorage.getItem('oauth_return_url') || '/';
+            const backUrl = localStorage.getItem('oauth_return_url') || '/';
+            localStorage.removeItem('oauth_link_mode');
+            localStorage.removeItem('oauth_provider');
             localStorage.removeItem('oauth_return_url');
-            router.push(returnUrl);
+            localStorage.removeItem('oauth_expect_mobile');
+            router.push(backUrl);
           }, 5000);
         }
       }
-    };
-
-    processCallback();
-  }, [router, searchParams, refreshAuth, hasProcessed]);
+    })();
+  }, [router, searchParams, refreshAuth, handleSuccess]);
 
   return (
     <Container size="sm" py="xl">
@@ -139,44 +274,32 @@ function OAuthCallbackContent() {
         {status === 'error' && 'Authentication error'}
       </Title>
 
-      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '2rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '1.25rem' }}>
         {status === 'processing' && <Loader size="lg" />}
       </div>
 
-      {status === 'success' && (
-        <Alert color="green" ta="center">
-          {message}
-        </Alert>
-      )}
+      <Stack gap="md" align="center">
+        {status === 'success' && <Alert color="green" ta="center">{message}</Alert>}
+        {status === 'error' && <Alert color="red" ta="center">{message}</Alert>}
+        {status === 'processing' && <Text ta="center">{message}</Text>}
 
-      {status === 'error' && (
-        <Alert color="red" ta="center">
-          {message}
-        </Alert>
-      )}
-
-      {status === 'processing' && (
-        <Text ta="center">
-          {message}
-        </Text>
-      )}
+        {showBrowserFallback && status !== 'success' && (
+          <Button
+            onClick={() => {
+              const code = searchParams.get('code')!;
+              const rawState = searchParams.get('state');
+              const state = parseState(rawState);
+              const storedProvider = (localStorage.getItem('oauth_provider') || state?.provider || 'github').toLowerCase();
+              const provider: Provider = storedProvider === 'google' ? 'google' : 'github';
+              const isLinkMode = localStorage.getItem('oauth_link_mode') === 'true';
+              const returnUrl = state?.returnUrl || localStorage.getItem('oauth_return_url') || '/';
+              forceWebExchange(code, provider, isLinkMode, returnUrl);
+            }}
+          >
+            Continue in browser
+          </Button>
+        )}
+      </Stack>
     </Container>
-  );
-}
-
-export default function OAuthCallbackPage() {
-  return (
-    <Suspense fallback={
-      <Container size="sm" py="xl">
-        <Title order={1} mb="xl" ta="center">
-          Loading...
-        </Title>
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <Loader size="lg" />
-        </div>
-      </Container>
-    }>
-      <OAuthCallbackContent />
-    </Suspense>
   );
 }

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -27,8 +27,6 @@ export const axios = Axios.create({
 
 axios.interceptors.request.use(
   (config) => {
-    config.withCredentials = true;
-
     config.headers['Content-Type'] = config.headers['Content-Type'] || 'application/json';
 
     if (process.env.NEXT_PUBLIC_ENVIRONMENT === 'development') {

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -25,6 +25,13 @@ export const axios = Axios.create({
   withCredentials: true,
 });
 
+try {
+  Axios.defaults.baseURL = API_CONFIG.baseURL;
+  Axios.defaults.withCredentials = true;
+} catch (e) {
+  console.warn('Failed to set global axios defaults:', e);
+}
+
 axios.interceptors.request.use(
   (config) => {
     config.headers['Content-Type'] = config.headers['Content-Type'] || 'application/json';

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -28,7 +28,13 @@ const mockProviders: OAuthProvider[] = [
 
 export const getOAuthProviders = async (): Promise<OAuthProvider[]> => {
   if (USE_MOCK_DATA)
-    return Promise.resolve(mockProviders);
+    return Promise.resolve(mockProviders.map(p => ({
+      providerKey: p.providerKey,
+      providerLabel: p.providerLabel,
+      providerLogoUrl: p.providerLogoUrl,
+      userAuthUrl: '#',
+      clientId: ''
+    })));
 
   try {
     const response = await axios.get(`${API_CONFIG.baseURL}/api/oauth/providers`);

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -7,21 +7,21 @@ const mockProviders: OAuthProvider[] = [
     providerKey: 'google',
     providerLabel: 'Google',
     providerLogoUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/1024px-Google_%22G%22_logo.svg.png",
-    userAuthUrl: '#',
+    userAuthUrl: 'mock://oauth-url',
     clientId: 'mock'
   },
   {
     providerKey: 'microsoft',
     providerLabel: 'Microsoft',
     providerLogoUrl: "https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg",
-    userAuthUrl: '#',
+    userAuthUrl: 'mock://oauth-url',
     clientId: 'mock'
   },
   {
     providerKey: 'github',
     providerLabel: 'GitHub',
     providerLogoUrl: "https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg",
-    userAuthUrl: '#',
+    userAuthUrl: 'mock://oauth-url',
     clientId: 'mock'
   },
 ];


### PR DESCRIPTION
## Description
- What: Implement and enhance OAuth flow to support mobile deep links and improved error handling for OAuth callback exchange. The branch adds mobile app detection, deeplink redirection, browser fallback, and better exchange handling (including linking mode). Also includes UI changes for messages and integration with auth refresh.
- Why: To allow the mobile application to perform OAuth sign-in via deep links while preserving web fallback and robust error reporting for users.

## Changes
- Frontend:
  - Add `src/app/oauth-callback/page.tsx` updates to detect mobile clients, attempt app deep-linking, and fallback to browser exchange when needed.
  - Handle 'link' mode for account linking using `/api/oauth-link/{provider}/exchange` endpoints.
  - Improved status messages and user feedback (loader, success/error alerts, continue-in-browser button).
  - Add localStorage/sessionStorage usage for preserving oauth state: `oauth_link_mode`, `oauth_provider`, `oauth_return_url`, `oauth_expect_mobile`, deeplink attempt key.
- Services:
  - `src/services/oauthService.ts` provides methods: `getOAuthProviders`, `initiateOAuth`, and helper `connectGitHubForTesting`.
- Config/Docs:
  - Docs reference for OAuth configuration updated in `docs/API_CONFIGURATION.md` (see OAuth section) and `.env.example` contains OAuth variables.

## Tests
### Added
- Unit: No new unit tests added on this branch (0 new). Existing tests cover OAuth provider retrieval and AuthenticationForm. Please add mobile deeplink tests if desired.
- Integration: No integration tests added (0 new).
- Functional/E2E: No new Cypress tests in this branch (0 new). — Total functional tests now: unchanged.

### Coverage
- Lines: not changed (project coverage unchanged)
- Branches: not changed

## Impact checklist (tick all that apply)
- [ ] DB schema change (migration included)
- [ ] Data migration
- [x] API contract change (request/response)
  - The frontend uses `/api/oauth/{provider}/exchange` and `/api/oauth-link/{provider}/exchange` POST endpoints with { code } payload; ensure backend accepts this.
- [ ] Config / env var change
- [ ] Dependency upgrades (runtime/build)
- [ ] Infra / CI/CD change
- [x] User-facing UI change (attach screenshots if relevant)
  - New OAuth callback UI messages and a button to continue in browser if deep-link fails.

## Deployment notes
- Migrations to run: none
- Config/env to set/update:
  - Ensure OAuth clients are configured for web & mobile and corresponding env vars set (see `.env.example`): client IDs and redirect URIs.

## Docs / Changelog
- [ ] Docs updated — None
- [ ] Changelog — Proposed entry: "feat(oauth): support mobile deep-links and improved OAuth callback handling + link mode"

---

### Author checklist
- [x] Clear “What/Why”
- [ ] Tests updated & green
- [x] Docs updated if needed
- [x] Labels/reviewers set

### Reviewer checklist
- Scope & rationale make sense
- Tests cover the change (if needed)
- Naming/structure reasonable

Notes for reviewer:
- The OAuth callback now tries to open the mobile app via a deep link when a mobile client is detected. If the app doesn't handle the link or the user is on web, a fallback exists to exchange the authorization code via the browser.
- The branch relies on backend endpoints to accept a POST to `/api/oauth/{provider}/exchange` with { code } and to provide `/api/oauth/providers`.
- Consider adding e2e coverage for mobile deeplink simulation and the browser fallback path.
